### PR TITLE
Update Android instructions

### DIFF
--- a/classes/pref/mobile.php
+++ b/classes/pref/mobile.php
@@ -4,9 +4,9 @@ class Pref_Mobile extends Handler_Protected {
       print "<h2>Android App Setup</h2>";
       print "<p>You can easily use this app on your Android device. Just follow these instructions:</p>";
       print "<ul>";
-      print "<li>Download <a href=\"/apk.php\">this apk</a> and install it on your Android device. You will have to enable installation from unknown sources by going to Settings > Security, and checking the \"Unknown Sources\" checkbox.</li>";
+      print "<li>Download an app.  The Tiny Tiny RSS authors maintain an <a href=\"https://play.google.com/store/apps/details?id=org.fox.ttrss\">app on Google Play</a>.  An app by a different author is available on <a href=\"https://f-droid.org/repository/browse/?fdid=org.ttrssreader\">FDroid</a>.</li>";
       print "<li>In the header bar of this site, you should see a key icon (you may need to open the menu). Click the key icon and create a new key. Save the webkey URL it gives you.</li>";
-      print "<li>Open the TinyTinyRss android app, and in its settings, paste the webkey URL you got from the previous step into the URL field.</li>";
+      print "<li>Open the app.  Set the host to be the part of the webkey before the #.  Set the HTTP Auth user to an arbitrary string and the HTTP Auth password to the part of the webkey after the #.</li>";
       print "<li>You should now be good to go!</li>";
       print "</ul>";
   }


### PR DESCRIPTION
The latest release on the Sandstorm App Market references an apk, but
does not contain one.

The specially-built APK added support for Bearer auth tokens.  This is
no longer necessary:
- Sandstorm now supports HTTP Authentication, providing another way to
  authenticate
- The two most popular Android apps for Tiny Tiny RSS support HTTP
  Authentication

Document how to make this work.
