### PR TITLE
Include Fever API plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins/fever"]
+	path = plugins/fever
+	url = https://github.com/dasmurphy/tinytinyrss-fever-plugin.git


### PR DESCRIPTION
There's a
[plugin](https://github.com/dasmurphy/tinytinyrss-fever-plugin) that
interprets [Fever](http://feedafever.com/) style API calls. If included
with TT-RSS this enables compatibility with the vast amount of Fever
compatible RSS clients out there on multiple platforms. It's a win!

Exposing it to outside is beyond my knowledge however.
